### PR TITLE
Array fix

### DIFF
--- a/data-miner/seed.js
+++ b/data-miner/seed.js
@@ -1,18 +1,70 @@
 const Aigle = require("aigle");
 const { MongoClient } = require("mongodb");
-const { get } = require("lodash");
 const hash = require("object-hash");
 const glob = require("glob");
 const { basename, extname } = require("path");
 const axios = require("axios");
 const { readFileSync } = require("fs-extra");
 const { DB_NAME, MONGO_URL, ENVS, FILES, VIEWS } = require("./config");
-const { pipeline } = require("stream");
-
+const { isEqual } = require("lodash")
 const debug = require("debug")("me_db:seed");
 
 const mongo = new MongoClient(MONGO_URL);
 const meDb = mongo.db(DB_NAME);
+
+
+const knownArrayPaths = [
+  /^Airbases\/\d+\/runways$/g,
+  /^Airbases\/\d+\/parking$/g,
+  /^Airodromes\/\d+\/projectors$/g,
+  /^Airodromes\/\d+\/beacons$/g,
+  /^Airodromes\/\d+\/runways$/g,
+  /^Airodromes\/\d+\/runwayName$/g,
+  /^Radios\/\d+\/frequency$/g,
+]
+
+
+
+function correctDataTypes(object, path = "") {
+  if (!object) return
+  Object.keys(object).forEach(function (k) {
+    const value = object[k]
+    if (typeof value !== "object" || value === undefined || value === null) return
+  
+    const newpath = `${path}/${k}`
+    const isArray = Array.isArray(value)
+    const ObjectKeys = Object.keys(value)
+    const isArrayExpected = knownArrayPaths.some(x => newpath.match(x))
+  
+    if (ObjectKeys.length == 0 && !isArray) {
+      if (isArrayExpected) {
+        object[k] = [];
+        return
+      }
+      console.warn(`Found empty object (should it be an array?): ${newpath}`)
+      return
+    } else {
+      if (!isArray) {
+        if (isEqual(ObjectKeys, ['0'])) {
+          if (isArrayExpected) {
+            object[k] = [value["0"]];
+          } else {
+            console.warn("Object with only 0 key maybe a array in disguise:", newpath, ObjectKeys, value)
+          }
+        } else if (isArrayExpected) {
+          console.log(`Force converted ${newpath} object to an array`)
+          object[k] = Object.values(value)
+        }
+      }
+
+
+      correctDataTypes(value, newpath);
+      return
+    }
+  });
+}
+
+
 
 const sign = (obj, dcsVersion) => {
   obj["_id"] = hash(obj);
@@ -23,20 +75,20 @@ const sign = (obj, dcsVersion) => {
 
 const populateCollection =
   (dcsVersion) =>
-  async ({ name, data }) => {
-    console.log(`Adding ${name} to DB`)
-    const collection = await meDb.collection(name);
+    async ({ name, data }) => {
+      console.log(`Adding ${name} to DB`)
+      const collection = await meDb.collection(name);
 
-    await Aigle.eachSeries(data, async (value, _) => {
-      try {
-        const signed = sign(value, dcsVersion);
-        // use upsert to avoid duplication when running more than once (Eg more than one theater)
-        await collection.updateOne({ _id: signed._id, '@dcsversion': signed['@dcsversion']  }, {$set: signed }, { upsert: true }); // TODO: Use Bulk Insert
-      } catch (e) {
-        debug(e.message);
-      }
-    });
-  };
+      await Aigle.eachSeries(data, async (value, _) => {
+        try {
+          const signed = sign(value, dcsVersion);
+          // use upsert to avoid duplication when running more than once (Eg more than one theater)
+          await collection.updateOne({ _id: signed._id, '@dcsversion': signed['@dcsversion'] }, { $set: signed }, { upsert: true }); // TODO: Use Bulk Insert
+        } catch (e) {
+          debug(e.message);
+        }
+      });
+    };
 
 async function run() {
   console.log("Validating Mongo Connection");
@@ -71,6 +123,7 @@ async function run() {
             console.error(e.message);
           }
         });
+      correctDataTypes(data, name)
       return { name, data };
     }
   );
@@ -81,10 +134,15 @@ async function run() {
   console.log("Populated Mission Editor DB");
 
   console.log("Creating Views")
-  await Aigle.eachSeries(await glob(VIEWS),  async (_path) => {
-    const {pipeline, collection, name} = require("./"+_path.replace("\\", "/"))
-    console.log(`Adding View ${name}`)
-    await meDb.command( { create: name, viewOn: collection, pipeline  });
+  await Aigle.eachSeries(await glob(VIEWS), async (_path) => {
+    try {
+      const { pipeline, collection, name } = require("./" + _path.replace("\\", "/"))
+      console.log(`Adding View ${name}`)
+      await meDb.command({ create: name, viewOn: collection, pipeline });
+    } catch (e) {
+      if (e.message.includes("Namespace already exists")) return
+      console.error(e.message);
+    }
   });
   console.log("Created Views")
 

--- a/data-miner/views/BR_airbases.js
+++ b/data-miner/views/BR_airbases.js
@@ -30,9 +30,7 @@ const pipeline = [
         'airdromeData': {
           'runways': {
             '$map': {
-              'input': {
-                '$objectToArray': '$raw.runways'
-              }, 
+              'input':'$raw.runways',
               'as': 'run', 
               'in': {
                 'name': '$$run.v.name'


### PR DESCRIPTION
We have a few instances where there is a reasonable likelihood that an object should actually be an array.

1. Empty lua arrays parse as objects
2. Lua Arrays with 1 item can parse as objects with Key "0"
3. Fields use Keys rather than an array radio/frequency is one

The system doesn't auto-convert stuff it first checks a `knownArrayPaths` list of regexes and only converts if it has a match (note ^ and $ to make sure its a full match)